### PR TITLE
Barre de vie des mobs visible seulement en combat

### DIFF
--- a/Source/Client/Modules Sources/modGameLogic.bas
+++ b/Source/Client/Modules Sources/modGameLogic.bas
@@ -743,7 +743,7 @@ rest:
                  If MapNpc(i).num > 0 And MapNpc(i).num < MAX_NPCS Then
                      If CLng(Npc(MapNpc(i).num).Vol) = 0 Then
                          Call BltNpc(i)
-                         If AccOpt.NpcBar Then Call BltNpcBars(i)
+                         If AccOpt.NpcBar And MapNpc(i).AttackTimer > 0 Then Call BltNpcBars(i)
                      End If
                  End If
              Next i


### PR DESCRIPTION
Avec ce simple petit ajout de rien du tout, les barres de vie des mobs ne deviennent visible qu'en combat (cela retire donc par défaut toutes les barres de vie de shopper et de pnj friendly)

Il faut toujours que l'option soit activé, mais une condition est ajouter pour vérifier si le pnj est en combat
